### PR TITLE
Clean temp file in the same step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV FRAPPE_USER=frappe \
 RUN useradd $FRAPPE_USER && mkdir /home/$FRAPPE_USER && chown -R $FRAPPE_USER.$FRAPPE_USER /home/$FRAPPE_USER
 WORKDIR /home/$FRAPPE_USER
 RUN wget https://raw.githubusercontent.com/frappe/bench/master/playbooks/install.py && sed -i "s/'', ''/'$MYSQL_PASSWORD', '$ADMIN_PASSWORD'/g" install.py && \
-    apt update && python install.py --production --user $FRAPPE_USER
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ /home/$FRAPPE_USER/.cache
+    apt update && python install.py --production --user $FRAPPE_USER && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ /home/$FRAPPE_USER/.cache
 COPY production.conf /etc/supervisor/conf.d/
 WORKDIR /home/$FRAPPE_USER/frappe-bench
 EXPOSE 80 25


### PR DESCRIPTION
Hello

Leaving "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ /home/$FRAPPE_USER/.cache" will leave the temp file in the intermerdiate layer of the docker file system and the final image will be bigger.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file;

(b) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: William Moreno Reyes williamjmorenor@gmail.com